### PR TITLE
New methods to handle alphavector policies

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 StatsBase
 POMDPs 0.6
+POMDPToolbox 0.2.6

--- a/src/ParticleFilters.jl
+++ b/src/ParticleFilters.jl
@@ -10,6 +10,7 @@ import POMDPs: implemented
 import POMDPs: sampletype
 import Base: rand, mean
 
+using POMDPToolbox
 using StatsBase
 
 export

--- a/src/ParticleFilters.jl
+++ b/src/ParticleFilters.jl
@@ -6,6 +6,7 @@ using POMDPs
 import POMDPs: pdf, mode, update, initialize_belief, iterator
 import POMDPs: state_type, isterminal, observation
 import POMDPs: generate_s
+import POMDPs: action, value
 import POMDPs: implemented
 import POMDPs: sampletype
 import Base: rand, mean
@@ -222,5 +223,6 @@ include("beliefs.jl")
 include("updater.jl")
 include("resamplers.jl")
 include("obs_weight.jl")
+include("policies.jl")
 
 end # module

--- a/src/policies.jl
+++ b/src/policies.jl
@@ -1,0 +1,26 @@
+#=
+Implementation specific to using ParticleBeliefs with AlphaVectorPolicy from POMDPToolbox
+these are more efficient than converting the ParticleBelief to a DiscreteBelief 
+=#
+
+"""
+Given a particle belief, return the unnormalized utility function that weights each state value by the weight of 
+the corresponding particle 
+    unnormalized_util(p::AlphaVectorPolicy, b::AbstractParticleBelief)
+"""
+function unnormalized_util(p::AlphaVectorPolicy, b::AbstractParticleBelief)
+    util = zeros(n_actions(p.pomdp))
+    for (i, s) in enumerate(particles(b))
+        j = state_index(p.pomdp, s)
+        util += weight(b, i)*getindex.(p.alphas, (j,))
+    end
+    return util
+end
+
+function action(p::AlphaVectorPolicy, b::AbstractParticleBelief)
+    util = unnormalized_util(p, b)
+    ihi = indmax(util)
+    return p.action_map[ihi]
+end
+
+value(p::AlphaVectorPolicy, b::AbstractParticleBelief) = maximum(unnormalized_util(p, b))/weight_sum(b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using ParticleFilters
 using POMDPs
 using POMDPModels
+using POMDPToolbox
 using Base.Test
 
 import ParticleFilters: obs_weight
@@ -43,3 +44,16 @@ bp = update(uf, ps, a, o)
 wp1 = collect(weighted_particles(ParticleCollection([1,2])))
 wp2 = collect(weighted_particles(WeightedParticleBelief([1,2], [0.5, 0.5])))
 @test wp1 == wp2
+
+# test specific method for alpha vector policies and particle beliefs
+pomdp = BabyPOMDP()
+# these values were gotten from FIB.jl
+alphas = [-29.4557 -36.5093; -19.4557 -16.0629]
+policy = AlphaVectorPolicy(pomdp, alphas)
+
+# initial belief is 100% confidence in baby being hungry
+b = ParticleCollection([true for i=1:100])
+
+# because baby is hungry, policy should feed (return true)
+@test action(policy, b) == true
+@test isapprox(value(policy, b), -29.4557)


### PR DESCRIPTION
These are the modifications discussed in github.com/JuliaPOMDP/POMDPToolbox#69. 
It introduces an `action` and `value` method to work with alpha vector policies and particle beliefs. 

**Note**: ParticleFilters is now dependent on POMDPToolbox. 

I added `POMDPToolbox 0.2.6` to REQUIRE, I am not sure if this is the right version number to put there. 