### PR TITLE
parameterizing model in SimpleParticleFilter type

### DIFF
--- a/src/ParticleFilters.jl
+++ b/src/ParticleFilters.jl
@@ -140,17 +140,17 @@ A particle filter that calculates relative weights for each particle based on ob
 
 The resample field may be a function or an object that controls resampling. If it is a function `f`, `f(b, rng)` will be called. If it is an object, `o`, `resample(o, b, rng)` will be called, where `b` is a `WeightedParticleBelief`.
 """
-mutable struct SimpleParticleFilter{S,R,RNG<:AbstractRNG} <: Updater
-    model
+mutable struct SimpleParticleFilter{S,M,R,RNG<:AbstractRNG} <: Updater
+    model::M
     resample::R
     rng::RNG
     _particle_memory::Vector{S}
     _weight_memory::Vector{Float64}
 
-    SimpleParticleFilter{S, R, RNG}(model, resample, rng) where {S,R,RNG} = new(model, resample, rng, state_type(model)[], Float64[])
+    SimpleParticleFilter{S, M, R, RNG}(model, resample, rng) where {S,M,R,RNG} = new(model, resample, rng, state_type(model)[], Float64[])
 end
 function SimpleParticleFilter{R}(model, resample::R, rng::AbstractRNG)
-    SimpleParticleFilter{state_type(model),R,typeof(rng)}(model, resample, rng)
+    SimpleParticleFilter{state_type(model),typeof(model),R,typeof(rng)}(model, resample, rng)
 end
 SimpleParticleFilter(model, resample; rng::AbstractRNG=Base.GLOBAL_RNG) = SimpleParticleFilter(model, resample, rng)
 


### PR DESCRIPTION
The `model` field of `SimpleParticleFilter` had no type. The dreaded red bars appeared in `ProfileView` during the `update` function, specifically on calls to `isterminal(up.model, s)`, `generate_s(up.model, s, a, up.rng)`, and `obs_weight(up.model, s, a, sp, o)`.

This branch parameterizes `SimpleParticleFilter` by the `model` type and these performance issues disappeared.