### PR TITLE
Mean and cov of particle belief

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ repo = "https://github.com/JuliaPOMDP/ParticleFilters.jl"
 version = "0.5.2"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 POMDPLinter = "f3bd98c0-eb40-45e2-9eb1-f2763262d755"
 POMDPModelTools = "08074719-1b2a-587c-a292-00f91cc44415"
 POMDPPolicies = "182e52fb-cfd0-5e46-8c26-fd0667c990f4"

--- a/src/ParticleFilters.jl
+++ b/src/ParticleFilters.jl
@@ -16,7 +16,7 @@ using POMDPPolicies: AlphaVectorPolicy, alphavectors
 using POMDPModelTools: weighted_iterator 
 
 import Random: rand, gentype
-import Statistics: mean
+import Statistics: mean, cov, var
 
 export
     AbstractParticleBelief,

--- a/src/ParticleFilters.jl
+++ b/src/ParticleFilters.jl
@@ -9,6 +9,7 @@ using POMDPLinter: @implemented
 
 import POMDPModelTools: obs_weight
 using StatsBase
+using LinearAlgebra
 using Random
 using Statistics
 using POMDPPolicies: AlphaVectorPolicy, alphavectors

--- a/src/beliefs.jl
+++ b/src/beliefs.jl
@@ -93,7 +93,7 @@ ParticleCollection(p::AbstractVector{T}) where T = ParticleCollection{T}(p, noth
 
 n_particles(b::ParticleCollection) = length(b.particles)
 particles(p::ParticleCollection) = p.particles
-weights(b::ParticleCollection) = ones(n_particles(b))
+weights(b::ParticleCollection) = fill(1/n_particles(b),n_particles(b))
 weighted_particles(p::ParticleCollection) = (s=>1.0/length(p.particles) for s in p.particles)
 weight_sum(::ParticleCollection) = 1.0
 weight(b::ParticleCollection, i::Int) = 1.0/length(b.particles)

--- a/src/beliefs.jl
+++ b/src/beliefs.jl
@@ -145,7 +145,7 @@ end
 Statistics.mean(b::WeightedParticleBelief) = sum(b.weights .* b.particles) / weight_sum(b)
 function Statistics.cov(b::WeightedParticleBelief)
     diff = hcat(b.particles...) .- mean(b)
-    diff .* reshape(b.weights, 1, size(diff, 2)) * diff' / weight_sum(b)
+    (diff .* b.weights') * diff' / weight_sum(b)
 end
 
 ### Shared implementations ###

--- a/src/beliefs.jl
+++ b/src/beliefs.jl
@@ -93,10 +93,10 @@ ParticleCollection(p::AbstractVector{T}) where T = ParticleCollection{T}(p, noth
 
 n_particles(b::ParticleCollection) = length(b.particles)
 particles(p::ParticleCollection) = p.particles
-weights(b::ParticleCollection) = fill(1/n_particles(b),n_particles(b))
-weighted_particles(p::ParticleCollection) = (s=>1.0/length(p.particles) for s in p.particles)
-weight_sum(::ParticleCollection) = 1.0
-weight(b::ParticleCollection, i::Int) = 1.0/length(b.particles)
+weights(b::ParticleCollection) = ones(n_particles(b))
+weighted_particles(p::ParticleCollection) = (s=>1.0 for s in p.particles)
+weight_sum(b::ParticleCollection) = n_particles(b)
+weight(b::ParticleCollection, i::Int) = 1.0
 particle(b::ParticleCollection, i::Int) = b.particles[i]
 rand(rng::AbstractRNG, b::ParticleCollection) = b.particles[rand(rng, 1:length(b.particles))]
 Statistics.mean(b::ParticleCollection) = sum(b.particles)/length(b.particles)

--- a/test/beliefs.jl
+++ b/test/beliefs.jl
@@ -16,25 +16,33 @@ w = [4.0, 1.0, 1.0]
     @testset "unweighted" begin
         b = ParticleCollection(p)
         @inferred mean(b)
+        @inferred cov(b)
         @test mean(b) ≈ 10
-        @test cov(b) ≈ [8/3]
+        @test cov(b) ≈ 8/3
+        @test var(b) ≈ 8/3
 
         b = ParticleCollection(p2d)
         @inferred mean(b)
+        @inferred cov(b)
         @test mean(b) ≈ [10, 10]
         @test cov(b) ≈ fill(8/3, 2, 2)
         @test var(b) ≈ fill(8/3, 2)
     end
 
     @testset "weighted" begin
+        true_cov = cov([8, 8, 8, 8, 10, 12], corrected=false)
         b = WeightedParticleBelief(p, w)
         @inferred mean(b)
+        @inferred cov(b)
         @test mean(b) ≈ 9
-        cov(b)
+        @test cov(b) ≈ true_cov
+        @test var(b) ≈ true_cov
 
         b = WeightedParticleBelief(p2d, w)
-        # @inferred mean(b)  # not type stable
+        @inferred mean(b)
+        @inferred cov(b)
         @test mean(b) ≈ [9, 9]
-        cov(b)
+        @test cov(b) ≈ fill(true_cov, 2, 2)
+        @test var(b) ≈ fill(true_cov, 2)
     end
 end

--- a/test/beliefs.jl
+++ b/test/beliefs.jl
@@ -30,9 +30,11 @@ w = [4.0, 1.0, 1.0]
         b = WeightedParticleBelief(p, w)
         @inferred mean(b)
         @test mean(b) ≈ 9
+        cov(b)
 
         b = WeightedParticleBelief(p2d, w)
         # @inferred mean(b)  # not type stable
         @test mean(b) ≈ [9, 9]
+        cov(b)
     end
 end

--- a/test/beliefs.jl
+++ b/test/beliefs.jl
@@ -1,0 +1,38 @@
+using ParticleFilters
+using Test
+using Statistics
+
+p = [8, 10, 12]
+# particles in 2D state space
+p2d = [
+    [8, 8],
+    [10, 10],
+    [12, 12],
+]
+w = [4.0, 1.0, 1.0]
+
+@testset "beliefs" begin
+
+    @testset "unweighted" begin
+        b = ParticleCollection(p)
+        @inferred mean(b)
+        @test mean(b) ≈ 10
+        @test cov(b) ≈ [8/3]
+
+        b = ParticleCollection(p2d)
+        @inferred mean(b)
+        @test mean(b) ≈ [10, 10]
+        @test cov(b) ≈ fill(8/3, 2, 2)
+        @test var(b) ≈ fill(8/3, 2)
+    end
+
+    @testset "weighted" begin
+        b = WeightedParticleBelief(p, w)
+        @inferred mean(b)
+        @test mean(b) ≈ 9
+
+        b = WeightedParticleBelief(p2d, w)
+        # @inferred mean(b)  # not type stable
+        @test mean(b) ≈ [9, 9]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ end
 
 include("example.jl")
 include("domain_specific_resampler.jl")
+include("beliefs.jl")
 
 struct ContinuousPOMDP <: POMDP{Float64, Float64, Float64} end
 @testset "infer" begin


### PR DESCRIPTION
There is a problem with mean computation of `WeightedParticleBelief`

1. `dot` is not available without `using LinearAlgebra`
2. even then it only works for beliefs on real numbers, not on multidimensional state spaces

This generalizes mean computation to multi-dimensional spaces, but I couldn't find a type-stable way to do so.

This also implements covariance computation for `ParticleCollection` and `WeightedParticleBelief`, which I found useful (unfortunately also not type-stable).