### PR TITLE
Prevent LowVarianceResampler from crashing for weights close to machine precision

### DIFF
--- a/src/resamplers.jl
+++ b/src/resamplers.jl
@@ -60,7 +60,7 @@ function resample(re::LowVarianceResampler, b::AbstractParticleBelief{S}, rng::A
     i = 1
     U = r
     for m in 1:re.n
-        while U > c
+        while U > c && i < n_particles(b)
             i += 1
             c += weight(b, i)
         end


### PR DESCRIPTION
I think from a theoretic point of view this is not necessary, but I ran into problems with weights being close to machine precision.