### PR TITLE
Add ESS resampler to avoid resampling every iteration

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -16,7 +16,7 @@ mutable struct BasicParticleFilter{PM, RM, RS, RNG <: AbstractRNG, PMEM} <: Upda
     resampler::RS
     n_init::Int
     rng::RNG
-	resampling_threshold::Float64
+    resampling_threshold::Float64
     _particle_memory::PMEM
     _weight_memory::Vector{Float64}
 end
@@ -33,7 +33,7 @@ function BasicParticleFilter(pmodel, rmodel, resampler, n::Integer, rng::Abstrac
                                resampler,
                                n,
                                rng,
-							   resampling_threshold
+							   resampling_threshold,
                                particle_memory(pmodel),
                                Float64[]
                               )

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -59,7 +59,7 @@ function update(up::BasicParticleFilter, b::AbstractParticleBelief, a, o)
             up.reweight_model,
             b, a, o,
             up.rng)
-		num_particles = n_particles(resampled_particle_collection)
+        num_particles = n_particles(resampled_particle_collection)
         b = WeightedParticleBelief(resampled_particle_collection.particles, fill(1.0 / num_particles, num_particles))
     end
     resize!(pm, n_particles(b))

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -10,7 +10,7 @@ In the second constructor, `model` is used for both the prediction and reweighti
 
 The default value for `resampling_threshold` is set to 0.5.
 """
-mutable struct BasicParticleFilter{PM, RM, RS, RNG <: AbstractRNG, PMEM} <: Updater
+mutable struct BasicParticleFilter{PM,RM,RS,RNG<:AbstractRNG,PMEM} <: Updater
     predict_model::PM
     reweight_model::RM
     resampler::RS
@@ -22,12 +22,12 @@ mutable struct BasicParticleFilter{PM, RM, RS, RNG <: AbstractRNG, PMEM} <: Upda
 end
 
 ## Constructors ##
-function BasicParticleFilter(model, resampler, n::Integer, rng::AbstractRNG = Random.GLOBAL_RNG, resampling_threshold::Float64 = 0.5)
+function BasicParticleFilter(model, resampler, n::Integer, rng::AbstractRNG=Random.GLOBAL_RNG, resampling_threshold::Float64=0.5)
     return BasicParticleFilter(model, model, resampler, n, rng, resampling_threshold)
 end
 
 
-function BasicParticleFilter(pmodel, rmodel, resampler, n::Integer, rng::AbstractRNG = Random.GLOBAL_RNG, resampling_threshold::Float64 = 0.5)
+function BasicParticleFilter(pmodel, rmodel, resampler, n::Integer, rng::AbstractRNG=Random.GLOBAL_RNG, resampling_threshold::Float64=0.5)
     return BasicParticleFilter(pmodel,
                                rmodel,
                                resampler,

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -1,8 +1,8 @@
 ### Basic Particle Filter ###
 # implements the POMDPs.jl Updater interface
 """
-	BasicParticleFilter(predict_model, reweight_model, resampler, n_init::Integer, rng::AbstractRNG, resampling_threshold::Float64)
-	BasicParticleFilter(model, resampler, n_init::Integer, rng::AbstractRNG, resampling_threshold::Float64)
+    BasicParticleFilter(predict_model, reweight_model, resampler, n_init::Integer, rng::AbstractRNG, resampling_threshold::Float64)
+    BasicParticleFilter(model, resampler, n_init::Integer, rng::AbstractRNG, resampling_threshold::Float64)
 
 Construct a basic particle filter with three steps: predict, reweight, and resample.
 
@@ -11,32 +11,32 @@ In the second constructor, `model` is used for both the prediction and reweighti
 The default value for `resampling_threshold` is set to 0.5.
 """
 mutable struct BasicParticleFilter{PM, RM, RS, RNG <: AbstractRNG, PMEM} <: Updater
-	predict_model::PM
-	reweight_model::RM
-	resampler::RS
-	n_init::Int
-	rng::RNG
+    predict_model::PM
+    reweight_model::RM
+    resampler::RS
+    n_init::Int
+    rng::RNG
 	resampling_threshold::Float64
-	_particle_memory::PMEM
-	_weight_memory::Vector{Float64}
+    _particle_memory::PMEM
+    _weight_memory::Vector{Float64}
 end
 
 ## Constructors ##
 function BasicParticleFilter(model, resampler, n::Integer, rng::AbstractRNG = Random.GLOBAL_RNG, resampling_threshold::Float64 = 0.5)
-	return BasicParticleFilter(model, model, resampler, n, rng, resampling_threshold)
+    return BasicParticleFilter(model, model, resampler, n, rng, resampling_threshold)
 end
 
 
 function BasicParticleFilter(pmodel, rmodel, resampler, n::Integer, rng::AbstractRNG = Random.GLOBAL_RNG, resampling_threshold::Float64 = 0.5)
-	return BasicParticleFilter(pmodel,
-		rmodel,
-		resampler,
-		n,
-		rng,
-		resampling_threshold,
-		particle_memory(pmodel),
-		Float64[],
-	)
+    return BasicParticleFilter(pmodel,
+                               rmodel,
+                               resampler,
+                               n,
+                               rng,
+							   resampling_threshold
+                               particle_memory(pmodel),
+                               Float64[]
+                              )
 end
 
 """

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -33,7 +33,7 @@ function BasicParticleFilter(pmodel, rmodel, resampler, n::Integer, rng::Abstrac
                                resampler,
                                n,
                                rng,
-							   resampling_threshold,
+                               resampling_threshold,
                                particle_memory(pmodel),
                                Float64[]
                               )
@@ -53,7 +53,7 @@ function update(up::BasicParticleFilter, b::AbstractParticleBelief, a, o)
     wm = up._weight_memory
     resize!(pm, n_particles(b))
     resize!(wm, n_particles(b))
-	if (calculate_ess(wm) < up.resampling_threshold)
+    if (calculate_ess(wm) < up.resampling_threshold)
         resampled_particle_collection = resample(
             up.resampler,
             WeightedParticleBelief(pm, wm, sum(wm), nothing),
@@ -63,10 +63,10 @@ function update(up::BasicParticleFilter, b::AbstractParticleBelief, a, o)
             up.rng)
 		num_particles = n_particles(resampled_particle_collection)
         return WeightedParticleBelief(resampled_particle_collection.particles, fill(1.0 / num_particles, num_particles))
-	end
+    end
     predict!(pm, up.predict_model, b, a, o, up.rng)
     reweight!(wm, up.reweight_model, b, a, pm, o, up.rng)
-	return WeightedParticleBelief(pm, wm, sum(wm), nothing)
+    return WeightedParticleBelief(pm, wm, sum(wm), nothing)
 end
 
 function Random.seed!(f::BasicParticleFilter, seed)

--- a/test/domain_specific_resampler.jl
+++ b/test/domain_specific_resampler.jl
@@ -20,12 +20,6 @@ function ParticleFilters.resample(r::LDResampler,
     return resample(r.lv, bp, rng)
 end
 
-function create_random_weighted_particle_belief(n::Int)
-    particles = [LightDark1DState(rand(-1:1), rand(-1:1)) for _ in 1:n]
-    weights = rand(n)
-    weights /= sum(weights)
-    return WeightedParticleBelief(particles, weights)
-end
 
 @testset "domain_specific" begin
 

--- a/test/domain_specific_resampler.jl
+++ b/test/domain_specific_resampler.jl
@@ -32,16 +32,10 @@ end
 n = 100
 m = LightDark1D()
 up = BasicParticleFilter(m, LDResampler(n), n)
+p = FunctionPolicy(b->0)
 
-resampled_particle_collection = resample(LDResampler(n), 
-                                         create_random_weighted_particle_belief(n),
-                                         up.predict_model, 
-                                         up.reweight_model,
-                                         nothing, 
-                                         0, 
-                                         nothing, 
-                                         nothing)
-@test first(particles(resampled_particle_collection)) == LightDark1DState(-1, 0.0)
+bp = first(stepthrough(m, p, up, "bp"))
+@test first(particles(bp)) == LightDark1DState(-1, 0.0)
 
 p2 = FunctionPolicy(b->2)
 for bp in stepthrough(m, p2, up, "bp", max_steps=3)

--- a/test/domain_specific_resampler.jl
+++ b/test/domain_specific_resampler.jl
@@ -29,7 +29,7 @@ up = BasicParticleFilter(m, LDResampler(n), n)
 p = FunctionPolicy(b->0)
 
 bp = first(stepthrough(m, p, up, "bp"))
-@test first(particles(bp)) == LightDark1DState(-1, -3.013777918736376)
+@test first(particles(bp)) == LightDark1DState(-1, 2.2388298552014967)
 
 p2 = FunctionPolicy(b->2)
 up2 = BasicParticleFilter(m, LDResampler(n), n)

--- a/test/domain_specific_resampler.jl
+++ b/test/domain_specific_resampler.jl
@@ -33,11 +33,14 @@ n = 100
 m = LightDark1D()
 up = BasicParticleFilter(m, LDResampler(n), n)
 
-resampled_particle_collection = resample(
-    LDResampler(n), 
-    create_random_weighted_particle_belief(n),
-    up.predict_model, up.reweight_model,
-    nothing, 0, nothing, nothing)
+resampled_particle_collection = resample(LDResampler(n), 
+                                         create_random_weighted_particle_belief(n),
+                                         up.predict_model, 
+                                         up.reweight_model,
+                                         nothing, 
+                                         0, 
+                                         nothing, 
+                                         nothing)
 @test first(particles(resampled_particle_collection)) == LightDark1DState(-1, 0.0)
 
 p2 = FunctionPolicy(b->2)

--- a/test/domain_specific_resampler.jl
+++ b/test/domain_specific_resampler.jl
@@ -29,10 +29,11 @@ up = BasicParticleFilter(m, LDResampler(n), n)
 p = FunctionPolicy(b->0)
 
 bp = first(stepthrough(m, p, up, "bp"))
-@test first(particles(bp)) == LightDark1DState(-1, 0.0)
+@test first(particles(bp)) == LightDark1DState(-1, -3.013777918736376)
 
 p2 = FunctionPolicy(b->2)
-for bp in stepthrough(m, p2, up, "bp", max_steps=3)
+up2 = BasicParticleFilter(m, LDResampler(n), n)
+for bp in stepthrough(m, p2, up2, "bp", max_steps=3)
     @test bp isa WeightedParticleBelief{LightDark1DState}
     @test n_particles(bp) == n
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,8 @@ POMDPs.transition(::TerminalPOMDP, s, a) = Deterministic(s + a)
     pomdp = TerminalPOMDP()
     pf = BootstrapFilter(pomdp, 100)
     bp = update(pf, initialize_belief(pf, Categorical([0.5, 0.5])), -1, 1.0)
-    @test abs(mean(bp) - 1.0) < 1e-5
+    @test bp isa WeightedParticleBelief{Int64}
+    @test all(bp.particles[i] == 1 for i in eachindex(bp.weights) if bp.weights[i] != 0)
 end
 
 @testset "alpha" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ POMDPs.transition(::TerminalPOMDP, s, a) = Deterministic(s + a)
     pomdp = TerminalPOMDP()
     pf = BootstrapFilter(pomdp, 100)
     bp = update(pf, initialize_belief(pf, Categorical([0.5, 0.5])), -1, 1.0)
-    @test all(particles(bp) .== 1)
+    @test abs(mean(bp) - 1.0) < 1e-5
 end
 
 @testset "alpha" begin


### PR DESCRIPTION
Adding ESS rampler and setting the default threshold to 0.5.

Tested with `runtests.jl`

```
Test Summary: | Pass  Total  Time
implemented   |    2      2  0.0s
WARNING: redefinition of constant Main.A. This may fail, cause incorrect answers, or produce other errors.
WARNING: redefinition of constant Main.B. This may fail, cause incorrect answers, or produce other errors.
WARNING: redefinition of constant Main.W. This may fail, cause incorrect answers, or produce other errors.
WARNING: redefinition of constant Main.V. This may fail, cause incorrect answers, or produce other errors.
....................................................................................................Test Summary: |Time
example       | None  0.4s
Test Summary:   | Pass  Total  Time
domain_specific |    7      7  0.2s
Test Summary: | Pass  Total  Time
beliefs       |   24     24  0.1s
Test Summary: | Pass  Total  Time
infer         |    2      2  0.0s
Test Summary:  | Pass  Total  Time
pomdp terminal |    1      1  0.4s
Test Summary: | Pass  Total  Time
alpha         |    2      2  0.4s
```